### PR TITLE
Use include_globs to avoid manually entering every amazon.<> permutation

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,21 +6,15 @@
     "gecko": {
       "id": "abf@mosley.xyz",
       "strict_min_version": "113.0"
-      
     },
     "gecko_android": {
       "strict_min_version": "113.0"
     }
-    
   },
   "description": "Filters out all unknown brands from Amazon search results.",
-
   "icons": {
-      "128": "icons/abf-enabled-128.png"
-    },
-  
-  
-
+    "128": "icons/abf-enabled-128.png"
+  },
   "action": {
     "default_title": "Amazon Brand Filter",
     "default_area": "navbar",
@@ -33,22 +27,14 @@
   "content_scripts": [
     {
       "matches": [
-        "*://*.amazon.com/*",
-        "*://*.amazon.ca/*",
-        "*://*.amazon.com.au/*",
-        "*://*.amazon.co.uk/*",
-        "*://*.amazon.com.mx/*",
-        "*://*.amazon.de/*",
-        "*://*.amazon.fr/*",
-        "*://*.amazon.it/*",
-        "*://*.amazon.es/*",
-        "*://*.amazon.be/*",
-        "*://*.amazon.se/*"
-        ],
+        "*://*/*"
+      ],
+      "include_globs": [
+        "*://*.amazon.*/*"
+      ],
       "js": ["amazonbrandfilter.js"]
     }
   ],
-
   "content_security_policy": {
     "extension_pages": "default-src 'self'; script-src 'self'; object-src 'none'; connect-src https://raw.githubusercontent.com/chris-mosley/AmazonBrandFilterList/main/brands.txt https://api.github.com/repos/chris-mosley/AmazonBrandFilterList/releases/latest;"
   },
@@ -65,28 +51,11 @@
       "matches":["*://*/*"]
     }
   ],
-    
   "permissions": [
     "storage",
     "webRequest",
     "activeTab",
     "scripting",
     "tabs"
-  ],
-  "host_permissions": [
-    "*://*.amazon.com/*",
-    "*://*.amazon.ca/*",
-    "*://*.amazon.com.au/*",
-    "*://*.amazon.com.mx/*",
-    "*://*.amazon.co.uk/*",
-    "*://*.amazon.de/*",
-    "*://*.amazon.fr/*",
-    "*://*.amazon.it/*",
-    "*://*.amazon.es/*",
-    "*://*.amazon.be/*",
-    "*://*.amazon.se/*"
   ]
-
-
 }
-


### PR DESCRIPTION
- use include_globs when executing the content_script so that every permutation of amazon.<> does not have to be manually specified
- tested and it works but should be validated before merge
- useful [ref](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts#:~:text=URL%20patterns%20below.-,include_globs,-Array)
- does `host_permissions` need to be set? the `tabs` api is utilised but `tabs` permissions are already requested in the manifest. the `cookies` and `webRequest` apis do not seem to be used either. [ref](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/host_permissions)