### PR TITLE
Toggles working in real time (on and off) immediately without a page reload

### DIFF
--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -97,7 +97,7 @@ const filterRefiner = (settings: StorageSettings, syncSettings: StorageSettings)
       continue;
     }
 
-    if (!settings.brandsMap[brand]) {
+    if (!settings.brandsMap[brand] || (syncSettings.usePersonalBlock && syncSettings.personalBlockMap[brand])) {
       if (settings.refinerMode === "grey") {
         div.style.display = "block";
         div
@@ -105,29 +105,14 @@ const filterRefiner = (settings: StorageSettings, syncSettings: StorageSettings)
           ?.setAttribute("style", "display: block; color: grey !important;");
       } else {
         div.style.display = "none";
+        div
+          .getElementsByClassName("a-size-base a-color-base")[0]
+          ?.setAttribute("style", "display: block; color: black !important;");
       }
 
       if (settings.useDebugMode) {
         div.style.display = "block";
         div.style.backgroundColor = "red";
-      } else {
-        div.style.backgroundColor = "white";
-      }
-    }
-
-    if (syncSettings.usePersonalBlock && syncSettings.personalBlockMap[brand]) {
-      if (settings.refinerMode === "grey") {
-        div.style.display = "block";
-        div
-          .getElementsByClassName("a-size-base a-color-base")[0]
-          ?.setAttribute("style", "display: block; color: grey !important;");
-      } else {
-        div.style.display = "none";
-      }
-
-      if (settings.useDebugMode) {
-        div.style.display = "block";
-        div.style.backgroundColor = "yellow";
       } else {
         div.style.backgroundColor = "white";
       }

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -65,6 +65,8 @@ const descriptionSearch = async (settings: StorageSettings, div: HTMLDivElement)
             searchTerm +
             "</span><br>" +
             div.innerHTML;
+        } else {
+          div.style.backgroundColor = "white";
         }
         return;
       }
@@ -75,6 +77,7 @@ const descriptionSearch = async (settings: StorageSettings, div: HTMLDivElement)
     div.style.backgroundColor = "red";
   } else {
     div.style.display = "none";
+    div.style.backgroundColor = "white";
   }
 };
 
@@ -95,34 +98,38 @@ const filterRefiner = (settings: StorageSettings, syncSettings: StorageSettings)
     }
 
     if (!settings.brandsMap[brand]) {
+      if (settings.refinerMode === "grey") {
+        div.style.display = "block";
+        div
+          .getElementsByClassName("a-size-base a-color-base")[0]
+          ?.setAttribute("style", "display: block; color: grey !important;");
+      } else {
+        div.style.display = "none";
+      }
+
       if (settings.useDebugMode) {
         div.style.display = "block";
         div.style.backgroundColor = "red";
       } else {
-        if (settings.refinerMode === "grey") {
-          div.style.display = "block";
-          div
-            .getElementsByClassName("a-size-base a-color-base")[0]
-            ?.setAttribute("style", "display: block; color: grey !important;");
-        } else {
-          div.style.display = "none";
-        }
+        div.style.backgroundColor = "white";
       }
     }
 
     if (syncSettings.usePersonalBlock && syncSettings.personalBlockMap[brand]) {
+      if (settings.refinerMode === "grey") {
+        div.style.display = "block";
+        div
+          .getElementsByClassName("a-size-base a-color-base")[0]
+          ?.setAttribute("style", "display: block; color: grey !important;");
+      } else {
+        div.style.display = "none";
+      }
+
       if (settings.useDebugMode) {
         div.style.display = "block";
         div.style.backgroundColor = "yellow";
       } else {
-        if (settings.refinerMode === "grey") {
-          div.style.display = "block";
-          div
-            .getElementsByClassName("a-size-base a-color-base")[0]
-            ?.setAttribute("style", "display: block; color: grey !important;");
-        } else {
-          div.style.display = "none";
-        }
+        div.style.backgroundColor = "white";
       }
     }
   }
@@ -180,6 +187,8 @@ const filterBrands = async (settings: StorageSettings) => {
               searchTerm +
               "</span><br>" +
               div.innerHTML;
+          } else {
+            div.style.backgroundColor = "white";
           }
           continue;
         }
@@ -189,6 +198,7 @@ const filterBrands = async (settings: StorageSettings) => {
           div.style.backgroundColor = "red";
         } else {
           div.style.display = "none";
+          div.style.backgroundColor = "white";
         }
         continue;
       }
@@ -198,15 +208,36 @@ const filterBrands = async (settings: StorageSettings) => {
     if (shortText.length === 0) {
       continue;
     }
-    if (shortText.length === 0) {
-      continue;
-    }
     await descriptionSearch(settings, div);
   }
 
   if (settings.filterRefiner) {
     filterRefiner(settings, synchedSettings);
   }
+};
+
+/**
+ * resets the brands filter to the default Amazon settings (colors and display)
+ */
+const resetBrands = () => {
+  // reset sidebar
+  let divs = [];
+  divs = [
+    ...(document.getElementById("brandsRefinements")?.getElementsByClassName("a-spacing-micro") ?? []),
+  ] as HTMLDivElement[];
+  divs.forEach((div) => {
+    div.style.backgroundColor = "white";
+    div
+      .getElementsByClassName("a-size-base a-color-base")[0]
+      ?.setAttribute("style", "display: block; color: black !important;");
+    div.style.display = "block";
+  });
+  // reset search results
+  divs = [...getItemDivs()] as HTMLDivElement[];
+  divs.forEach((div) => {
+    div.style.backgroundColor = "white";
+    div.style.display = "block";
+  });
 };
 
 const listenForMessages = () => {
@@ -219,6 +250,8 @@ const listenForMessages = () => {
         if (message.isChecked) {
           filterBrands(settings);
         } else {
+          resetBrands();
+          // previously hidden elements should be shown
           unHideDivs();
         }
         break;

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -23,82 +23,6 @@ const checkBrandFilter = (): boolean => {
   return false;
 };
 
-const filterBrands = async (settings: StorageSettings) => {
-  const synchedSettings = await getStorageValue("sync");
-  const brands = settings.brandsMap;
-  if (Object.keys(brands).length === 0) {
-    console.log("AmazonBrandFilter: No brands found");
-    return;
-  }
-  console.log("AmazonBrandFilter: Brands found");
-
-  if (settings.refinerBypass) {
-    if (checkBrandFilter()) {
-      return;
-    }
-  }
-
-  const divs = getItemDivs();
-  for (const div of divs) {
-    const itemHeader = div.getElementsByClassName("s-line-clamp-1") as HTMLCollectionOf<HTMLDivElement>;
-    if (itemHeader.length !== 0) {
-      const searchTerm = itemHeader[0]?.innerText.toUpperCase();
-      if (searchTerm && settings.brandsMap[searchTerm]) {
-        if (synchedSettings.usePersonalBlock) {
-          if (synchedSettings.personalBlockMap[searchTerm]) {
-            if (settings.useDebugMode) {
-              // to make it easier to tell when something is hidden because
-              // it isnt found vs when it is hidden because it is blocked
-              div.style.display = "block";
-              div.style.backgroundColor = "yellow";
-              div.innerHTML =
-                "<span style='color: black; background-color: white;font-size: large;'>ABF DEBUG: " +
-                searchTerm +
-                "</span><br>" +
-                div.innerHTML;
-              continue;
-            } else {
-              div.style.display = "none";
-            }
-          }
-        } else {
-          if (settings.useDebugMode) {
-            div.style.display = "block";
-            div.style.backgroundColor = "green";
-            div.innerHTML =
-              "<span style='color: black; background-color: white;font-size: large;'>ABF DEBUG: " +
-              searchTerm +
-              "</span><br>" +
-              div.innerHTML;
-          }
-          continue;
-        }
-      } else {
-        if (settings.useDebugMode) {
-          div.style.display = "block";
-          div.style.backgroundColor = "red";
-        } else {
-          div.style.display = "none";
-        }
-        continue;
-      }
-    }
-
-    const shortText = div.getElementsByClassName("a-color-base a-text-normal") as HTMLCollectionOf<HTMLDivElement>;
-    if (shortText.length === 0) {
-      continue;
-    }
-    if (shortText.length === 0) {
-      continue;
-    }
-    await descriptionSearch(settings, div);
-  }
-
-  if (settings.filterRefiner) {
-    filterRefiner(settings, synchedSettings);
-  }
-};
-
 const descriptionSearch = async (settings: StorageSettings, div: HTMLDivElement) => {
   const synchedSettings = await getStorageValue("sync");
   const shortText = div.getElementsByClassName("a-color-base a-text-normal") as HTMLCollectionOf<HTMLDivElement>;
@@ -204,6 +128,87 @@ const filterRefiner = (settings: StorageSettings, syncSettings: StorageSettings)
   }
 };
 
+const filterBrands = async (settings: StorageSettings) => {
+  // do nothing if the extension is disabled
+  if (!settings.enabled) {
+    return;
+  }
+
+  const synchedSettings = await getStorageValue("sync");
+  const brands = settings.brandsMap;
+  if (Object.keys(brands).length === 0) {
+    console.log("AmazonBrandFilter: No brands found");
+    return;
+  }
+  console.log("AmazonBrandFilter: Brands found");
+
+  if (settings.refinerBypass) {
+    if (checkBrandFilter()) {
+      return;
+    }
+  }
+
+  const divs = getItemDivs();
+  for (const div of divs) {
+    const itemHeader = div.getElementsByClassName("s-line-clamp-1") as HTMLCollectionOf<HTMLDivElement>;
+    if (itemHeader.length !== 0) {
+      const searchTerm = itemHeader[0]?.innerText.toUpperCase();
+      if (searchTerm && settings.brandsMap[searchTerm]) {
+        if (synchedSettings.usePersonalBlock) {
+          if (synchedSettings.personalBlockMap[searchTerm]) {
+            if (settings.useDebugMode) {
+              // to make it easier to tell when something is hidden because
+              // it isnt found vs when it is hidden because it is blocked
+              div.style.display = "block";
+              div.style.backgroundColor = "yellow";
+              div.innerHTML =
+                "<span style='color: black; background-color: white;font-size: large;'>ABF DEBUG: " +
+                searchTerm +
+                "</span><br>" +
+                div.innerHTML;
+              continue;
+            } else {
+              div.style.display = "none";
+            }
+          }
+        } else {
+          if (settings.useDebugMode) {
+            div.style.display = "block";
+            div.style.backgroundColor = "green";
+            div.innerHTML =
+              "<span style='color: black; background-color: white;font-size: large;'>ABF DEBUG: " +
+              searchTerm +
+              "</span><br>" +
+              div.innerHTML;
+          }
+          continue;
+        }
+      } else {
+        if (settings.useDebugMode) {
+          div.style.display = "block";
+          div.style.backgroundColor = "red";
+        } else {
+          div.style.display = "none";
+        }
+        continue;
+      }
+    }
+
+    const shortText = div.getElementsByClassName("a-color-base a-text-normal") as HTMLCollectionOf<HTMLDivElement>;
+    if (shortText.length === 0) {
+      continue;
+    }
+    if (shortText.length === 0) {
+      continue;
+    }
+    await descriptionSearch(settings, div);
+  }
+
+  if (settings.filterRefiner) {
+    filterRefiner(settings, synchedSettings);
+  }
+};
+
 const listenForMessages = () => {
   getEngineApi().runtime.onMessage.addListener(async (message: PopupMessage) => {
     console.log({ type: message.type, isChecked: message.isChecked });
@@ -238,26 +243,28 @@ const listenForMessages = () => {
 };
 
 (async () => {
+  // listen for messages from the popup
   listenForMessages();
 
   unHideDivs();
 
-  const settings = await getStorageValue();
-  if (!settings.enabled) {
-    return;
-  }
-
   let previousUrl = "";
-  const observer = new MutationObserver((_mutations) => {
-    if (location.href !== previousUrl) {
-      previousUrl = location.href;
-      sleep(1000).then(() => {
-        const timerStart = performance.now();
-        filterBrands(settings);
-        const timerEnd = performance.now();
-        setStorageValue({ lastMapRun: timerEnd - timerStart });
-      });
+  const observer = new MutationObserver(async (_mutations) => {
+    if (location.href === previousUrl) {
+      return;
     }
+    previousUrl = location.href;
+
+    const settings = await getStorageValue();
+    if (!settings.enabled) {
+      return;
+    }
+
+    await sleep(1000);
+    const timerStart = performance.now();
+    filterBrands(settings);
+    const timerEnd = performance.now();
+    setStorageValue({ lastMapRun: timerEnd - timerStart });
   });
 
   const config = { attributes: true, childList: true, subtree: true };

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -82,6 +82,11 @@ const descriptionSearch = async (settings: StorageSettings, div: HTMLDivElement)
 };
 
 const filterRefiner = (settings: StorageSettings, syncSettings: StorageSettings) => {
+  // do nothing if not disabled
+  if (!settings.enabled || !settings.filterRefiner) {
+    return;
+  }
+
   const refiner = document.getElementById("brandsRefinements");
   if (!refiner) {
     return;
@@ -121,7 +126,7 @@ const filterRefiner = (settings: StorageSettings, syncSettings: StorageSettings)
 };
 
 const filterBrands = async (settings: StorageSettings) => {
-  // do nothing if the extension is disabled
+  // do nothing if not disabled
   if (!settings.enabled) {
     return;
   }
@@ -201,13 +206,8 @@ const filterBrands = async (settings: StorageSettings) => {
   }
 };
 
-/**
- * resets the brands filter to the default Amazon settings (colors and display)
- */
-const resetBrands = () => {
-  // reset sidebar
-  let divs = [];
-  divs = [
+const resetBrandsRefiner = () => {
+  const divs = [
     ...(document.getElementById("brandsRefinements")?.getElementsByClassName("a-spacing-micro") ?? []),
   ] as HTMLDivElement[];
   divs.forEach((div) => {
@@ -217,12 +217,24 @@ const resetBrands = () => {
       ?.setAttribute("style", "display: block; color: black !important;");
     div.style.display = "block";
   });
-  // reset search results
-  divs = [...getItemDivs()] as HTMLDivElement[];
+};
+
+const resetBrandsSearchResults = () => {
+  const divs = [...getItemDivs()] as HTMLDivElement[];
   divs.forEach((div) => {
     div.style.backgroundColor = "white";
     div.style.display = "block";
   });
+};
+
+/**
+ * resets the brands filter to the default Amazon settings (colors and display)
+ */
+const resetBrands = () => {
+  // reset refiner
+  resetBrandsRefiner();
+  // reset search results
+  resetBrandsSearchResults();
 };
 
 const listenForMessages = () => {
@@ -251,6 +263,9 @@ const listenForMessages = () => {
         filterBrands(settings);
         break;
       case "filterRefiner":
+        resetBrandsRefiner();
+        filterRefiner(settings, synchedSettings);
+        break;
       case "refinerMode":
         filterRefiner(settings, synchedSettings);
         break;

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -25,10 +25,7 @@ const checkBrandFilter = (): boolean => {
 
 const filterBrands = async (settings: StorageSettings) => {
   const synchedSettings = await getStorageValue("sync");
-  console.log("AmazonBrandFilter: synchedSettings are: " + JSON.stringify(synchedSettings));
-  console.log("AmazonBrandFilter: Starting filterBrands");
   const brands = settings.brandsMap;
-  console.log("AmazonBrandFilter: Brands are " + JSON.stringify(brands));
   if (Object.keys(brands).length === 0) {
     console.log("AmazonBrandFilter: No brands found");
     return;
@@ -52,6 +49,7 @@ const filterBrands = async (settings: StorageSettings) => {
             if (settings.useDebugMode) {
               // to make it easier to tell when something is hidden because
               // it isnt found vs when it is hidden because it is blocked
+              div.style.display = "block";
               div.style.backgroundColor = "yellow";
               div.innerHTML =
                 "<span style='color: black; background-color: white;font-size: large;'>ABF DEBUG: " +
@@ -65,6 +63,7 @@ const filterBrands = async (settings: StorageSettings) => {
           }
         } else {
           if (settings.useDebugMode) {
+            div.style.display = "block";
             div.style.backgroundColor = "green";
             div.innerHTML =
               "<span style='color: black; background-color: white;font-size: large;'>ABF DEBUG: " +
@@ -76,6 +75,7 @@ const filterBrands = async (settings: StorageSettings) => {
         }
       } else {
         if (settings.useDebugMode) {
+          div.style.display = "block";
           div.style.backgroundColor = "red";
         } else {
           div.style.display = "none";
@@ -101,7 +101,6 @@ const filterBrands = async (settings: StorageSettings) => {
 
 const descriptionSearch = async (settings: StorageSettings, div: HTMLDivElement) => {
   const synchedSettings = await getStorageValue("sync");
-  console.log("AmazonBrandFilter: synchedSettings are: " + JSON.stringify(synchedSettings));
   const shortText = div.getElementsByClassName("a-color-base a-text-normal") as HTMLCollectionOf<HTMLDivElement>;
   if (shortText.length === 0) {
     return;
@@ -121,6 +120,7 @@ const descriptionSearch = async (settings: StorageSettings, div: HTMLDivElement)
             if (settings.useDebugMode) {
               // to make it easier to tell when something is hidden because
               // it isnt found vs when it is hidden because it is blocked
+              div.style.display = "block";
               div.style.backgroundColor = "yellow";
               div.innerHTML =
                 "<span style='color: black; background-color: white;font-size: large;'>ABF DEBUG: " +
@@ -134,6 +134,7 @@ const descriptionSearch = async (settings: StorageSettings, div: HTMLDivElement)
           }
         }
         if (settings.useDebugMode) {
+          div.style.display = "block";
           div.style.backgroundColor = "green";
           div.innerHTML =
             "<span style='color: black; background-color: white;font-size: large;'>ABF DEBUG: " +
@@ -146,6 +147,7 @@ const descriptionSearch = async (settings: StorageSettings, div: HTMLDivElement)
     }
   }
   if (settings.useDebugMode) {
+    div.style.display = "block";
     div.style.backgroundColor = "red";
   } else {
     div.style.display = "none";
@@ -170,6 +172,7 @@ const filterRefiner = (settings: StorageSettings, syncSettings: StorageSettings)
 
     if (!settings.brandsMap[brand]) {
       if (settings.useDebugMode) {
+        div.style.display = "block";
         div.style.backgroundColor = "red";
       } else {
         if (settings.refinerMode === "grey") {
@@ -185,6 +188,7 @@ const filterRefiner = (settings: StorageSettings, syncSettings: StorageSettings)
 
     if (syncSettings.usePersonalBlock && syncSettings.personalBlockMap[brand]) {
       if (settings.useDebugMode) {
+        div.style.display = "block";
         div.style.backgroundColor = "yellow";
       } else {
         if (settings.refinerMode === "grey") {
@@ -212,6 +216,16 @@ const listenForMessages = () => {
         } else {
           unHideDivs();
         }
+        break;
+      case "refinerBypass":
+        if (message.isChecked) {
+          if (checkBrandFilter()) {
+            return;
+          }
+        }
+        break;
+      case "useDebugMode":
+        filterBrands(settings);
         break;
       case "filterRefiner":
       case "refinerMode":

--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -169,12 +169,13 @@ const setRefinerBypass = async (_event: Event) => {
   sendMessageToContentScriptPostClick({ type: "refinerBypass", isChecked: abfAllowRefineBypass.checked });
 };
 
-const setDebugMode = (_event: Event) => {
+const setDebugMode = async (_event: Event) => {
   if (abfDebugMode.checked) {
-    setStorageValue({ useDebugMode: true });
+    await setStorageValue({ useDebugMode: true });
   } else {
-    setStorageValue({ useDebugMode: false });
+    await setStorageValue({ useDebugMode: false });
   }
+  sendMessageToContentScriptPostClick({ type: "useDebugMode", isChecked: abfDebugMode.checked });
 };
 
 const savePersonalBlock = async () => {

--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -1,4 +1,5 @@
-import { getManifest, getMessage, getStorageValue, setIcon, setStorageValue } from "utils/helpers";
+import { getEngineApi, getManifest, getMessage, getStorageValue, setIcon, setStorageValue } from "utils/helpers";
+import { PopupMessage } from "utils/types";
 
 const abfEnabled = document.getElementById("abf-enabled")! as HTMLInputElement;
 const abfFilterRefiner = document.getElementById("abf-filter-refiner")! as HTMLInputElement;
@@ -24,14 +25,13 @@ const abfAllowRefineBypassText = document.getElementById("abf-allow-refine-bypas
 const abfDebugModeText = document.getElementById("abf-debug-mode-text")! as HTMLInputElement;
 const abfPersonalBlockEnabledText = document.getElementById("abf-personal-block-enabled-text")! as HTMLInputElement;
 
-const abfPersonalBlockSavedConfirmText = document.getElementById("abf-personal-block-saved-confirm")! as HTMLSpanElement;
+const abfPersonalBlockText = document.getElementById("abf-personal-block-saved-confirm")! as HTMLSpanElement;
 const brandListVersionText = document.getElementById("popup-brand-version-text")! as HTMLSpanElement;
 const brandCountText = document.getElementById("popup-brand-count-text")! as HTMLSpanElement;
 const feedbackText = document.getElementById("popup-feedback-text")! as HTMLSpanElement;
 const missingBrandText = document.getElementById("popup-missing-brand-text")! as HTMLSpanElement;
 const lastRunText = document.getElementById("last-run")! as HTMLSpanElement;
 const helptranslate = document.getElementById("popup-help-translate")! as HTMLSpanElement;
-
 
 const setText = async () => {
   // these have to be snake_case because chrome doesnt support hyphens in i18n
@@ -43,20 +43,19 @@ const setText = async () => {
   abfDebugModeText.innerText = await getMessage("popup_debug");
   abfPersonalBlockEnabledText.innerText = await getMessage("popup_personal_blocklist");
   abfPersonalBlockButton.innerText = await getMessage("popup_save_button");
-  
-  abfPersonalBlockSavedConfirmText.innerText = await getMessage("popup_save_confirm");
+
+  abfPersonalBlockText.innerText = await getMessage("popup_save_confirm");
   brandListVersionText.innerText = await getMessage("popup_list_version");
   brandCountText.innerText = await getMessage("popup_list_count");
   feedbackText.innerText = await getMessage("popup_feedback_link");
   missingBrandText.innerText = await getMessage("popup_missing_brand");
   lastRunText.innerText = await getMessage("popup_last_run");
   helptranslate.innerText = await getMessage("popup_help_translate");
-}
-
+};
 
 const setPopupBoxStates = async () => {
   console.log("AmazonBrandFilter: Setting Popup Box States");
-// attempt to get the sync settings first, then fall back to local
+  // attempt to get the sync settings first, then fall back to local
   let settings = await getStorageValue("sync");
   if (Object.keys(settings).length === 0) {
     settings = await getStorageValue();
@@ -122,47 +121,52 @@ const setTextBoxStates = async () => {
 
 const enableDisable = async (_event: Event) => {
   if (abfEnabled.checked) {
-    setStorageValue({ enabled: true });
+    await setStorageValue({ enabled: true });
   } else {
-    setStorageValue({ enabled: false });
+    await setStorageValue({ enabled: false });
   }
-  setIcon();
+  await setIcon();
+  sendMessageToContentScriptPostClick({ type: "enabled", isChecked: abfEnabled.checked });
 };
 
-const setFilterRefiner = (_event: Event) => {
+const setFilterRefiner = async (_event: Event) => {
   if (abfFilterRefiner.checked) {
-    setStorageValue({ filterRefiner: true });
+    await setStorageValue({ filterRefiner: true });
   } else {
-    setStorageValue({ filterRefiner: false });
+    await setStorageValue({ filterRefiner: false });
   }
+  sendMessageToContentScriptPostClick({ type: "filterRefiner", isChecked: abfFilterRefiner.checked });
 };
 
-const setRefinerHide = (_event: Event) => {
+const setRefinerHide = async (_event: Event) => {
   if (abfFilterRefinerHide.checked) {
-    setStorageValue({ refinerMode: "hide" });
     abfFilterRefinerGrey.checked = false;
+    await setStorageValue({ refinerMode: "hide" });
   } else {
     abfFilterRefinerGrey.checked = true;
-    setStorageValue({ refinerMode: "grey" });
+    await setStorageValue({ refinerMode: "grey" });
   }
+  sendMessageToContentScriptPostClick({ type: "refinerMode", isChecked: abfFilterRefinerHide.checked });
 };
 
-const setRefinerGrey = (_event: Event) => {
+const setRefinerGrey = async (_event: Event) => {
   if (abfFilterRefinerGrey.checked) {
-    setStorageValue({ refinerMode: "grey" });
     abfFilterRefinerHide.checked = false;
+    await setStorageValue({ refinerMode: "grey" });
   } else {
     abfFilterRefinerHide.checked = true;
-    setStorageValue({ refinerMode: "hide" });
+    await setStorageValue({ refinerMode: "hide" });
   }
+  sendMessageToContentScriptPostClick({ type: "refinerMode", isChecked: abfFilterRefinerGrey.checked });
 };
 
-const setRefinerBypass = (_event: Event) => {
+const setRefinerBypass = async (_event: Event) => {
   if (abfAllowRefineBypass.checked) {
-    setStorageValue({ refinerBypass: true });
+    await setStorageValue({ refinerBypass: true });
   } else {
-    setStorageValue({ refinerBypass: false });
+    await setStorageValue({ refinerBypass: false });
   }
+  sendMessageToContentScriptPostClick({ type: "refinerBypass", isChecked: abfAllowRefineBypass.checked });
 };
 
 const setDebugMode = (_event: Event) => {
@@ -226,6 +230,16 @@ const setPersonalBlockEnabled = () => {
     abfPersonalBlockTextBox.style.display = "none";
     abfPersonalBlockButton.style.display = "none";
   }
+};
+
+const sendMessageToContentScriptPostClick = (message: PopupMessage) => {
+  getEngineApi().tabs.query({ active: true, currentWindow: true }, (tabs) => {
+    const activeTab = tabs[0];
+    if (!activeTab || !activeTab.id) {
+      return;
+    }
+    getEngineApi().tabs.sendMessage(activeTab.id, message);
+  });
 };
 
 setPopupBoxStates();

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -3,7 +3,7 @@ import { browser } from "webextension-polyfill-ts";
 import { Engine, StorageApiProps, StorageSettings } from "utils/types";
 
 /**
- * Retrieves the name of the browser engine based on the runtime environment.
+ * retrieves the name of the browser engine based on the runtime environment.
  *
  * @returns
  */
@@ -12,6 +12,22 @@ export const getEngine = (): Engine => {
     return "chromium";
   } else if (typeof browser !== "undefined") {
     return "gecko";
+  } else {
+    throw new Error("Unsupported engine.");
+  }
+};
+
+/**
+ * retrieves the API object for the current browser environment.
+ *
+ * @returns
+ */
+export const getEngineApi = () => {
+  const engine = getEngine();
+  if (engine === "chromium") {
+    return chrome;
+  } else if (engine === "gecko") {
+    return browser;
   } else {
     throw new Error("Unsupported engine.");
   }
@@ -74,27 +90,26 @@ export const setStorageValue = async (
 };
 
 export const getMessage = async (message: string): Promise<string> => {
-  const engine= getEngine();
-  if(engine == "gecko" && browser.i18n) {
+  const engine = getEngine();
+  if (engine == "gecko" && browser.i18n) {
     return browser.i18n.getMessage(message);
-  } else if(engine == "chromium" && chrome.i18n) {
+  } else if (engine == "chromium" && chrome.i18n) {
     return chrome.i18n.getMessage(message);
   } else {
-    throw new Error("Unsupported engine.")
+    throw new Error("Unsupported engine.");
   }
-}
+};
 
 export const setIcon = async () => {
-  const engine = getEngine();
   const result = await getStorageValue("enabled");
   if (result.enabled) {
-    (engine === "gecko" ? chrome : browser).action.setIcon({
+    getEngineApi().action.setIcon({
       path: {
         48: "icons/abf-enabled-128.png",
       },
     });
   } else {
-    (engine === "gecko" ? chrome : browser).action.setIcon({
+    getEngineApi().action.setIcon({
       path: {
         48: "icons/abf-disabled-128.png",
       },

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,6 +1,7 @@
 export type Engine = "gecko" | "chromium";
 
 export type StorageApiProps = "local" | "sync";
+
 export interface StorageSettings {
   abfFirstRun: boolean;
   brandsMap: { [key: string]: boolean };
@@ -8,12 +9,19 @@ export interface StorageSettings {
   brandsVersion: number | null;
   enabled: boolean;
   filterRefiner: boolean;
+  refinerMode: "grey" | "hide";
+  refinerBypass: boolean;
   lastMapRun: number;
   maxWordCount: number;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  personalBlockMap: any; // TODO: fix this
-  refinerBypass: boolean;
-  refinerMode: string;
+  personalBlockMap: any; // TODO: should not be any
   usePersonalBlock: boolean;
   useDebugMode: boolean;
+}
+
+export type PopupMessageType = keyof StorageSettings;
+
+export interface PopupMessage {
+  type: PopupMessageType;
+  isChecked: boolean;
 }


### PR DESCRIPTION
- for example, toggling the `enabled` switch to the "on" position will hide the relevant brands, and toggling it the "off" position will show the ads that have been hidden without a page reload
- working:
  - `enabled`
  - `filter sidebar` (grey and hide)
  - `filter bypass` (just calls the `checkBrandFilter` function) 
  - `debug mode`
- ensure that the `MutationObserver` is always executed within the content script IIFE, and that the return statements happen within the observer callback rather than within the IIFE
- simplify some of the logic for the `filterRefiner` function (`yellow` colour no longer used, now only `red` but code readability is much better)
- removed some of the logs cluttering the console