### PR TITLE
Ensure single version usage

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,7 +18,7 @@
       }
     ]
   },
-  "ignorePatterns": ["node_modules/", "dist/", "*.config.js"],
+  "ignorePatterns": ["node_modules/", "dist/", "*.config.js", "scripts/"],
   "env": {
     "browser": true,
     "webextensions": true

--- a/engines/chromium/manifest.json
+++ b/engines/chromium/manifest.json
@@ -1,7 +1,6 @@
 {
   "name": "amazon-brand-filter",
   "description": "amazon-brand-filter",
-  "version": "0.3.0",
   "manifest_version": 3,
   "default_locale": "en",
   "icons": {

--- a/engines/gecko/manifest.json
+++ b/engines/gecko/manifest.json
@@ -1,7 +1,6 @@
 {
   "name": "AmazonBrandFilter",
   "description": "Filters out all unknown brands from Amazon search results.",
-  "version": "0.3.0",
   "manifest_version": 3,
   "browser_specific_settings": {
     "gecko": {

--- a/package.json
+++ b/package.json
@@ -37,11 +37,9 @@
     "package": "web-ext build",
     "prepare": "husky install",
     "lint": "yarn eslint src/**/*.ts",
-    "win-build-gecko": "Remove-Item dist -Recurse -Force; webpack --mode development --config webpack.gecko.config.js",
-    "win-build-chromium": "Remove-Item dist -Recurse -Force; webpack --mode development --config webpack.chromium.config.js",
-    "win-watch-gecko": "Remove-Item dist -Recurse -Force; webpack --mode development --config webpack.gecko.config.js --watch",
-    "nix-build-gecko": "rm -rf dist && webpack --mode development --config webpack.gecko.config.js",
-    "nix-build-chromium": "rm -rf dist && webpack --mode development --config webpack.chromium.config.js",
-    "nix-watch-gecko": "rm -rf dist && webpack --mode development --config webpack.gecko.config.js --watch"
+    "win-build-gecko": "Remove-Item dist -Recurse -Force; webpack --mode development --config webpack.gecko.config.js; node scripts\\post-build-update-manifest.js",
+    "win-build-chromium": "Remove-Item dist -Recurse -Force; webpack --mode development --config webpack.chromium.config.js; node scripts\\post-build-update-manifest.js",
+    "nix-build-gecko": "rm -rf dist && webpack --mode development --config webpack.gecko.config.js && node scripts/post-build-update-manifest.js",
+    "nix-build-chromium": "rm -rf dist && webpack --mode development --config webpack.chromium.config.js && node scripts/post-build-update-manifest.js"
   }
 }

--- a/scripts/post-build-update-manifest.js
+++ b/scripts/post-build-update-manifest.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const path = require('path');
+
+// read the version from package.json
+const packageJson = require('../package.json');
+const extensionVersion = packageJson.version;
+const manifestFilePath = path.join(__dirname, `../dist/manifest.json`);
+
+try {
+  // read the manifest file
+  const manifest = JSON.parse(fs.readFileSync(manifestFilePath));
+
+  // update the version
+  manifest.version = extensionVersion;
+
+  // write the updated manifest file
+  fs.writeFileSync(manifestFilePath, JSON.stringify(manifest, null, 2));
+
+  console.log(`Version updated to ${extensionVersion} in manifest.json.`);
+} catch (error) {
+  console.error(`Error updating manifest.json: ${error.message}`);
+}


### PR DESCRIPTION
- remove `version` from `manifest.json` files
- add a script which runs post build that adds the version to the `manifest.json` (irrespective of the engine used for the build)
- the `version` used (source of truth) will be the version specified in `package.json`. this will help prevent different builds having different versions if all versions are not updated simultaneously
- update the build scripts to automatically run the new script post build (commands unchanged but the `--watch` scripts have been removed as they will not work with this change)