### PR TITLE
Fix storage default values so that all required StorageSettings keys are set

### DIFF
--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -95,22 +95,20 @@ const setPopupBoxStates = async () => {
     abfFilterRefinerGrey.checked = false;
   }
 
-  setIcon();
+  versionNumber.innerText = syncSettings.brandsVersion?.toString() ?? "";
+  brandCount.innerText = syncSettings.brandsCount?.toString() ?? "";
 
-  if (syncSettings.lastMapRun != null) {
-    versionNumber.innerText = syncSettings.brandsVersion?.toString() ?? "";
-    brandCount.innerText = syncSettings.brandsCount?.toString() ?? "";
-
-    if (syncSettings.lastMapRun) {
-      lastRun.innerText = syncSettings.lastMapRun + "ms";
-    } else {
-      lastRun.innerText = "N/A";
-    }
-
-    if (syncSettings.useDebugMode) {
-      abfDebugMode.checked = true;
-    }
+  if (syncSettings.lastMapRun) {
+    lastRun.innerText = `${syncSettings.lastMapRun}ms`;
+  } else {
+    lastRun.innerText = "N/A";
   }
+
+  if (syncSettings.useDebugMode) {
+    abfDebugMode.checked = true;
+  }
+
+  setIcon();
 };
 
 const setAddonVersion = () => {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,3 +1,26 @@
+import { StorageSettings } from "utils/types";
+
 // eslint-disable-next-line max-len
 export const latestReleaseUrl: string =
   "https://api.github.com/repos/chris-mosley/AmazonBrandFilterList/releases/latest";
+
+// don't copy brandsMap for sync storage
+export const defaultSyncStorageValue: Omit<StorageSettings, "brandsMap"> = {
+  isFirstRun: false,
+  brandsVersion: 0,
+  brandsCount: 0,
+  enabled: true,
+  filterRefiner: false,
+  refinerMode: "grey",
+  refinerBypass: true,
+  usePersonalBlock: false,
+  useDebugMode: false,
+  personalBlockMap: {},
+  lastMapRun: null,
+  maxWordCount: 0,
+};
+
+export const defaultLocalStorageValue: StorageSettings = {
+  ...defaultSyncStorageValue,
+  brandsMap: {},
+};

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -3,10 +3,10 @@ export type Engine = "gecko" | "chromium";
 export type StorageApiProps = "local" | "sync";
 
 export interface StorageSettings {
-  abfFirstRun: boolean;
-  brandsMap: { [key: string]: boolean };
-  brandsCount: number | null;
+  isFirstRun: boolean;
   brandsVersion: number | null;
+  brandsCount: number | null;
+  brandsMap: Record<string, boolean>;
   enabled: boolean;
   filterRefiner: boolean;
   refinerMode: "grey" | "hide";
@@ -14,8 +14,8 @@ export interface StorageSettings {
   usePersonalBlock: boolean;
   personalBlockMap: Record<string, boolean>;
   useDebugMode: boolean;
-  lastMapRun: number;
   maxWordCount: number;
+  lastMapRun: number | null;
 }
 
 export type PopupMessageType = keyof StorageSettings;


### PR DESCRIPTION
- add default values when setting storage (do not include `brandsMap` when setting sync storage as chrome will complain)
- check that all storage values have a default for runs that are not the first run for backwards compatibility
- do not overwrite settings for runs that are not the first run if the settings already exist
- some refactoring like function and variable name changes