### PR TITLE
added activetab permission, test for amazon.com url

### DIFF
--- a/engines/chromium/manifest.json
+++ b/engines/chromium/manifest.json
@@ -13,5 +13,5 @@
     "service_worker": "background.js",
     "type": "module"
   },
-  "permissions": ["storage"]
+  "permissions": ["storage", "activeTab"]
 }

--- a/engines/gecko/manifest.json
+++ b/engines/gecko/manifest.json
@@ -38,5 +38,5 @@
       "matches": ["*://*/*"]
     }
   ],
-  "permissions": ["storage"]
+  "permissions": ["storage", "activeTab"]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "AmazonBrandFilter",
   "description": "Filters out all unknown brands from Amazon search results.",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "keywords": [],
   "author": "",
   "license": "MIT",

--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -237,7 +237,7 @@ const setPersonalList = async () => {
 const sendMessageToContentScriptPostClick = (message: PopupMessage) => {
   getEngineApi().tabs.query({ active: true, currentWindow: true }, (tabs) => {
     const activeTab = tabs[0];
-    if (!activeTab || !activeTab.id) {
+    if (!activeTab || !activeTab.id || !activeTab.url?.includes(".amazon.")) {
       return;
     }
     getEngineApi().tabs.sendMessage(activeTab.id, message);


### PR DESCRIPTION
I think @barrymun warned me about this when I was trimming down permissions but I didn't understand what he was saying at the time.

this resolves a small error that occurs when you access the popup while not on an amazon page.  The console will log an error that the connection doesn't exist.

So now (with the addtional activeTab permission) we check to see if the url is an amazon url and if so we return.