### PR TITLE
Local storage values should always be set when sync storage values are set by the user in the popup

### DIFF
--- a/engines/chromium/manifest.json
+++ b/engines/chromium/manifest.json
@@ -1,17 +1,6 @@
 {
-  "manifest_version": 3,
-  "default_locale": "en",
-  "icons": {
-    "128": "icons/abf-disabled-128.png"
-  },
-  "action": {
-    "default_title": "amazon-brand-filter",
-    "default_area": "navbar",
-    "default_popup": "popup.html"
-  },
   "background": {
     "service_worker": "background.js",
     "type": "module"
-  },
-  "permissions": ["storage", "activeTab"]
+  }
 }

--- a/engines/common/manifest/base.json
+++ b/engines/common/manifest/base.json
@@ -1,0 +1,13 @@
+{
+  "manifest_version": 3,
+  "default_locale": "en",
+  "icons": {
+    "128": "icons/abf-disabled-128.png"
+  },
+  "permissions": ["storage", "activeTab"],
+  "action": {
+    "default_title": "Amazon Brand Filter",
+    "default_area": "navbar",
+    "default_popup": "popup.html"
+  }
+}

--- a/engines/gecko/manifest.json
+++ b/engines/gecko/manifest.json
@@ -1,5 +1,4 @@
 {
-  "manifest_version": 3,
   "browser_specific_settings": {
     "gecko": {
       "id": "abf@mosley.xyz",
@@ -8,15 +7,6 @@
     "gecko_android": {
       "strict_min_version": "113.0"
     }
-  },
-  "default_locale": "en",
-  "icons": {
-    "128": "icons/abf-enabled-128.png"
-  },
-  "action": {
-    "default_title": "Amazon Brand Filter",
-    "default_area": "navbar",
-    "default_popup": "popup.html"
   },
   "background": {
     "scripts": ["background.js"],
@@ -37,6 +27,5 @@
       "resources": ["brands.txt"],
       "matches": ["*://*/*"]
     }
-  ],
-  "permissions": ["storage", "activeTab"]
+  ]
 }

--- a/scripts/post-build-update-manifest.js
+++ b/scripts/post-build-update-manifest.js
@@ -3,6 +3,7 @@ const path = require("path");
 
 const rootPath = path.resolve("./");
 const packageJson = require(`${rootPath}/package.json`);
+const baseManifestJson = require(`${rootPath}/engines/common/manifest/base.json`);
 const contentScriptsJson = require(`${rootPath}/engines/common/manifest/content-scripts.json`);
 const manifestFilePath = path.resolve(__dirname, `${rootPath}/dist/manifest.json`);
 
@@ -14,7 +15,7 @@ try {
   manifest.version = packageJson.version;
   manifest.name = packageJson.name;
   manifest.description = packageJson.description;
-  manifest = { ...manifest, ...contentScriptsJson };
+  manifest = { ...manifest, ...baseManifestJson, ...contentScriptsJson };
 
   // write the updated manifest file
   fs.writeFileSync(manifestFilePath, JSON.stringify(manifest, null, 2));

--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -123,78 +123,49 @@ const setTextBoxStates = async () => {
 };
 
 const enableDisable = async (_event: Event) => {
-  if (abfEnabled.checked) {
-    await setStorageValue({ enabled: true });
-  } else {
-    await setStorageValue({ enabled: false });
-  }
+  await setStorageValue({ enabled: abfEnabled.checked }, "sync");
+  await setStorageValue({ enabled: abfEnabled.checked });
   await setIcon();
   sendMessageToContentScriptPostClick({ type: "enabled", isChecked: abfEnabled.checked });
 };
 
 const setFilterRefiner = async (_event: Event) => {
-  if (abfFilterRefiner.checked) {
-    await setStorageValue({ filterRefiner: true });
-  } else {
-    await setStorageValue({ filterRefiner: false });
-  }
+  await setStorageValue({ filterRefiner: abfFilterRefiner.checked }, "sync");
+  await setStorageValue({ filterRefiner: abfFilterRefiner.checked });
   sendMessageToContentScriptPostClick({ type: "filterRefiner", isChecked: abfFilterRefiner.checked });
 };
 
 const setRefinerHide = async (_event: Event) => {
-  if (abfFilterRefinerHide.checked) {
-    abfFilterRefinerGrey.checked = false;
-    await setStorageValue({ refinerMode: "hide" });
-  } else {
-    abfFilterRefinerGrey.checked = true;
-    await setStorageValue({ refinerMode: "grey" });
-  }
+  abfFilterRefinerGrey.checked = !abfFilterRefinerHide.checked;
+  await setStorageValue({ refinerMode: abfFilterRefinerHide.checked ? "hide" : "grey" }, "sync");
+  await setStorageValue({ refinerMode: abfFilterRefinerHide.checked ? "hide" : "grey" });
   sendMessageToContentScriptPostClick({ type: "refinerMode", isChecked: abfFilterRefinerHide.checked });
 };
 
 const setRefinerGrey = async (_event: Event) => {
-  if (abfFilterRefinerGrey.checked) {
-    abfFilterRefinerHide.checked = false;
-    await setStorageValue({ refinerMode: "grey" });
-  } else {
-    abfFilterRefinerHide.checked = true;
-    await setStorageValue({ refinerMode: "hide" });
-  }
+  abfFilterRefinerHide.checked = !abfFilterRefinerGrey.checked;
+  await setStorageValue({ refinerMode: abfFilterRefinerGrey.checked ? "grey" : "hide" }, "sync");
+  await setStorageValue({ refinerMode: abfFilterRefinerGrey.checked ? "grey" : "hide" });
   sendMessageToContentScriptPostClick({ type: "refinerMode", isChecked: abfFilterRefinerGrey.checked });
 };
 
 const setRefinerBypass = async (_event: Event) => {
-  if (abfAllowRefineBypass.checked) {
-    await setStorageValue({ refinerBypass: true });
-  } else {
-    await setStorageValue({ refinerBypass: false });
-  }
+  await setStorageValue({ refinerBypass: abfAllowRefineBypass.checked }, "sync");
+  await setStorageValue({ refinerBypass: abfAllowRefineBypass.checked });
   sendMessageToContentScriptPostClick({ type: "refinerBypass", isChecked: abfAllowRefineBypass.checked });
 };
 
 const setDebugMode = async (_event: Event) => {
-  if (abfDebugMode.checked) {
-    await setStorageValue({ useDebugMode: true });
-  } else {
-    await setStorageValue({ useDebugMode: false });
-  }
+  await setStorageValue({ useDebugMode: abfDebugMode.checked }, "sync");
+  await setStorageValue({ useDebugMode: abfDebugMode.checked });
   sendMessageToContentScriptPostClick({ type: "useDebugMode", isChecked: abfDebugMode.checked });
 };
 
 const setPersonalBlockEnabled = async (_event: Event) => {
-  if (abfPersonalBlockEnabled.checked) {
-    // set the usePersonalBlock in both local and sync storage
-    await setStorageValue({ usePersonalBlock: true }, "sync");
-    await setStorageValue({ usePersonalBlock: true });
-    abfPersonalBlockTextBox.style.display = "block";
-    abfPersonalBlockButton.style.display = "block";
-  } else {
-    // set the usePersonalBlock in both local and sync storage
-    await setStorageValue({ usePersonalBlock: false }, "sync");
-    await setStorageValue({ usePersonalBlock: false });
-    abfPersonalBlockTextBox.style.display = "none";
-    abfPersonalBlockButton.style.display = "none";
-  }
+  abfPersonalBlockTextBox.style.display = abfPersonalBlockEnabled.checked ? "block" : "none";
+  abfPersonalBlockButton.style.display = abfPersonalBlockEnabled.checked ? "block" : "none";
+  await setStorageValue({ usePersonalBlock: abfPersonalBlockEnabled.checked }, "sync");
+  await setStorageValue({ usePersonalBlock: abfPersonalBlockEnabled.checked });
   sendMessageToContentScriptPostClick({ type: "usePersonalBlock", isChecked: abfPersonalBlockEnabled.checked });
 };
 
@@ -204,7 +175,6 @@ const savePersonalBlock = async () => {
   for (const brand of userInput) {
     personalBlockMap[brand] = true;
   }
-  // set the personalBlockMap in both local and sync storage
   await setStorageValue({ personalBlockMap }, "sync");
   await setStorageValue({ personalBlockMap });
   abfPersonalBlockSavedConfirm.style.display = "block";


### PR DESCRIPTION
### changes:

- reformat the manifest files to remove duplicated keys
- clean up the popup logic so that is less verbose
- ensure that the settings are changed in both sync and local storage when the user alters the popup settings. setting the values in local handles cases whereby the sync storage cannot be set (e.g., for unauthenticated chrome users)