### PR TITLE
Stricter mutation observer rules so that the filter is run less frequently

### DIFF
--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -310,7 +310,26 @@ const runFilter = async () => {
 
 const startObserver = async () => {
   console.log("AmazonBrandFilter: Starting observer!");
-  const observer = new MutationObserver(async (_mutations) => {
+  const observer = new MutationObserver(async (mutations) => {
+    // check if the mutation is invalid
+    let mutationInvalid = false;
+    for (const mutation of mutations) {
+      if (mutation.type !== "childList") {
+        continue;
+      }
+      mutationInvalid = Array.from(mutation.addedNodes).some(
+        (node) =>
+          // check if the node is a carousel card class (these are the revolving ads)
+          (node as HTMLElement).classList?.contains("a-carousel-card") ||
+          // check if the node contains the text "ends in" (lowercase)
+          (node.nodeType === 3 && (node as Text).textContent?.toLowerCase().includes("ends in"))
+      );
+    }
+
+    if (mutationInvalid) {
+      return;
+    }
+
     console.log("AmazonBrandFilter: Mutation detected!");
     runFilter();
   });


### PR DESCRIPTION
### changes

- stricter rules within the context observer (new logic will ignore carousel and timer updates on the page)
- this will also help address some of the `Uncaught (in promise) Error: Extension context invalidated.` errors